### PR TITLE
Speed up by opening the large files only once

### DIFF
--- a/catchment_analyses.py
+++ b/catchment_analyses.py
@@ -15,6 +15,13 @@ hydro_model_list = [('VIC', 'calib_inverse', 'P1'),
 downscaling = 'maca'
 locations = pd.read_csv('./rupp_et_al_2020_locations.csv', header=None)[0].values
 
+# Load all the masks
+mask = {}
+for location_id in locations:
+    mask_path = '/pool0/data/orianac/FROM_RAID9/temp/remapped/remapUH_{}.nc'.format(location_id)
+    mask[location_id] = xr.open_dataset(mask_path).fraction
+
+
 for (hydro_model, path_parameter_name, official_convention) in hydro_model_list:
     for scenario in scenario_list:
         for gcm in gcm_list:
@@ -38,9 +45,7 @@ for (hydro_model, path_parameter_name, official_convention) in hydro_model_list:
                             gcm=gcm)
                 try:
                     print('Processing file {} for location {}'.format(file_path, location_id))
-                    mask_path = '/pool0/data/orianac/FROM_RAID9/temp/remapped/remapUH_{}.nc'.format(location_id)
-                    mask = xr.open_dataset(mask_path).fraction
-                    data_subset = data.where(mask)
+                    data_subset = data.where(mask[location_id])
                     data_subset.mean(dim=['lat', 'lon']).to_netcdf(out_path)
                 except:
                     print('Oh no! Something failed for {} for location {}'.format(file_path, location_id))

--- a/catchment_analyses.py
+++ b/catchment_analyses.py
@@ -20,9 +20,9 @@ mask = {}
 for location_id in locations:
     try: 
         mask_path = '/pool0/data/orianac/FROM_RAID9/temp/remapped/remapUH_{}.nc'.format(location_id)
+        mask[location_id] = xr.open_dataset(mask_path).fraction
     except: 
         print('Failed to open mask: {}'.format(mask_path))
-    mask[location_id] = xr.open_dataset(mask_path).fraction
 
 
 for (hydro_model, path_parameter_name, official_convention) in hydro_model_list:

--- a/catchment_analyses.py
+++ b/catchment_analyses.py
@@ -18,12 +18,18 @@ locations = pd.read_csv('./rupp_et_al_2020_locations.csv', header=None)[0].value
 for (hydro_model, path_parameter_name, official_convention) in hydro_model_list:
     for scenario in scenario_list:
         for gcm in gcm_list:
+            # open the large file only once - then process all locations
+            file_path = '/pool0/data/orianac/bpa/output_files_from_hyak/output_files/merged.19500101-20991231.nc.{hydro_model}.{downscaling}.{scenario}.{path_parameter_name}.{gcm}'.format(hydro_model=hydro_model,
+                        downscaling=downscaling,
+                        scenario=scenario,
+                        path_parameter_name=path_parameter_name,
+                        gcm=gcm)
+            try:
+                data = xr.open_dataset(file_path)
+            except:
+                print('Failed to open {}'.format(file_path))
+
             for location_id in locations:
-                file_path = '/pool0/data/orianac/bpa/output_files_from_hyak/output_files/merged.19500101-20991231.nc.{hydro_model}.{downscaling}.{scenario}.{path_parameter_name}.{gcm}'.format(hydro_model=hydro_model,
-                            downscaling=downscaling,
-                            scenario=scenario,
-                            path_parameter_name=path_parameter_name,
-                            gcm=gcm)
                 out_path = '/pool0/data/orianac/crcc/rupp_et_al_2020/catchment_{location_id}_mean_19500101-20991231_{scenario}_{gcm}_{downscaling}_{hydro_model}-{official_convention}.nc'.format(location_id=location_id,
                         hydro_model=hydro_model,
                             downscaling=downscaling,
@@ -32,11 +38,10 @@ for (hydro_model, path_parameter_name, official_convention) in hydro_model_list:
                             gcm=gcm)
                 try:
                     print('Processing file {} for location {}'.format(file_path, location_id))
-                    data = xr.open_dataset(file_path)
                     mask_path = '/pool0/data/orianac/FROM_RAID9/temp/remapped/remapUH_{}.nc'.format(location_id)
                     mask = xr.open_dataset(mask_path).fraction
-                    data = data.where(mask)
-                    data.mean(dim=['lat', 'lon']).to_netcdf(out_path)
+                    data_subset = data.where(mask)
+                    data_subset.mean(dim=['lat', 'lon']).to_netcdf(out_path)
                 except:
                     print('Oh no! Something failed for {} for location {}'.format(file_path, location_id))
 

--- a/catchment_analyses.py
+++ b/catchment_analyses.py
@@ -18,7 +18,10 @@ locations = pd.read_csv('./rupp_et_al_2020_locations.csv', header=None)[0].value
 # Load all the masks
 mask = {}
 for location_id in locations:
-    mask_path = '/pool0/data/orianac/FROM_RAID9/temp/remapped/remapUH_{}.nc'.format(location_id)
+    try: 
+        mask_path = '/pool0/data/orianac/FROM_RAID9/temp/remapped/remapUH_{}.nc'.format(location_id)
+    except: 
+        print('Failed to open mask: {}'.format(mask_path))
     mask[location_id] = xr.open_dataset(mask_path).fraction
 
 
@@ -32,9 +35,10 @@ for (hydro_model, path_parameter_name, official_convention) in hydro_model_list:
                         path_parameter_name=path_parameter_name,
                         gcm=gcm)
             try:
+                print('Processing data file: {}'.format(file_path))
                 data = xr.open_dataset(file_path)
             except:
-                print('Failed to open {}'.format(file_path))
+                print('Failed to open data file: {}'.format(file_path))
 
             for location_id in locations:
                 out_path = '/pool0/data/orianac/crcc/rupp_et_al_2020/catchment_{location_id}_mean_19500101-20991231_{scenario}_{gcm}_{downscaling}_{hydro_model}-{official_convention}.nc'.format(location_id=location_id,
@@ -44,7 +48,7 @@ for (hydro_model, path_parameter_name, official_convention) in hydro_model_list:
                             official_convention=official_convention,
                             gcm=gcm)
                 try:
-                    print('Processing file {} for location {}'.format(file_path, location_id))
+                    print('\tProcessing location {}'.format(location_id))
                     data_subset = data.where(mask[location_id])
                     data_subset.mean(dim=['lat', 'lon']).to_netcdf(out_path)
                 except:


### PR DESCRIPTION
Hi @orianac -

I made one major change: I pulled the opening of the large file outside of the inner loop so that the file will be opened only once. I think this may be the slowest step knowing h2o. It won't make the first location any faster (because you still need to open the large file once), but should make the following 30+ locations much faster. In the inner loop I avoid overwriting `data` by calling the masked subset `data_subset.

Let me know if this makes a difference. I did not test it. 

Bart